### PR TITLE
Support NonEmpty T path pieces

### DIFF
--- a/test/GeneratorSpec.hs
+++ b/test/GeneratorSpec.hs
@@ -38,27 +38,27 @@ spec = do
               "users"
               [ Path "api"
               , Path "users"
-              , Dyn Number
+              , Dyn NumberT
               ]
             , Method
               "users_bar"
               [ Path "api"
               , Path "users"
-              , Dyn (NonEmpty Number)
+              , Dyn (NonEmptyT NumberT)
               , Path "bar"
               ]
             , Method
               "users_baz"
               [ Path "api"
               , Path "users"
-              , Dyn String
+              , Dyn StringT
               , Path "baz"
               ]
             , Method
               "users_foo"
               [ Path "api"
               , Path "users"
-              , Dyn Number
+              , Dyn NumberT
               , Path "foo"
               ]
             ]
@@ -72,11 +72,11 @@ spec = do
             [ Method
               "y"
               [ Path "x"
-              , Dyn String
+              , Dyn StringT
               , Path "y"
-              , Dyn Number
+              , Dyn NumberT
               , Path "z"
-              , Dyn String
+              , Dyn StringT
               ]
             ]
           ]
@@ -99,7 +99,7 @@ spec = do
             [ Method
               "y"
               [ Path "x"
-              , Dyn (NonEmpty (NonEmpty Number))
+              , Dyn (NonEmptyT (NonEmptyT NumberT))
               , Path "y"
               ]
             ]

--- a/test/GeneratorSpec.hs
+++ b/test/GeneratorSpec.hs
@@ -1,0 +1,153 @@
+module GeneratorSpec where
+
+import TestImport
+import Data.List.NonEmpty (NonEmpty(..))
+
+type UserId = Int
+type NonEmptyUserId = NonEmpty UserId
+
+resources :: [ResourceTree String]
+resources = [parseRoutes|
+  /api ApiP:
+    /users/#UserId UsersR GET
+    /users/#Int/foo UsersFooR GET
+    /users/#NonEmptyUserId/bar UsersBarR GET
+    /users/#Other/baz UsersBazR GET
+|]
+
+spec :: Spec
+spec = do
+  describe "genFlowClasses" $ do
+    it "should generate classes" $ do
+      let classes = genFlowClasses [] [] resources
+      map className classes
+        `shouldBe`
+          [ "PATHS_TYPE_paths"
+          , "PATHS_TYPE_paths_static_pages"
+          , "PATHS_TYPE_paths_api"
+          ]
+
+    it "should identify path variable types" $ do
+      let
+        classes = genFlowClasses [] [] resources
+        apiClass = find ((== "PATHS_TYPE_paths_api") . className) classes
+      map classMembers apiClass
+        `shouldBe`
+          Just
+            [ Method
+              "users"
+              [ Path "api"
+              , Path "users"
+              , Dyn Number
+              ]
+            , Method
+              "users_bar"
+              [ Path "api"
+              , Path "users"
+              , Dyn (NonEmpty Number)
+              , Path "bar"
+              ]
+            , Method
+              "users_baz"
+              [ Path "api"
+              , Path "users"
+              , Dyn String
+              , Path "baz"
+              ]
+            , Method
+              "users_foo"
+              [ Path "api"
+              , Path "users"
+              , Dyn Number
+              , Path "foo"
+              ]
+            ]
+
+  describe "classesToFlow" $ do
+    it "should generate formal parameters for each path variable" $ do
+      let
+        cls =
+          [ Class
+            "x"
+            [ Method
+              "y"
+              [ Path "x"
+              , Dyn String
+              , Path "y"
+              , Dyn Number
+              , Path "z"
+              , Dyn String
+              ]
+            ]
+          ]
+      normalizeText (classesToFlow cls)
+        `shouldBe`
+          normalizeText [st|
+            class x {
+              y(a: string, aa: number, aaa: string): string { return this.root + '/x/' + a + '/y/' + aa.toString() + '/z/' + aaa + ''; }
+              root: string;
+              constructor(root: string) {
+                this.root = root;
+              }
+            }
+          |]
+    it "should avoid name shadowing in nested binders" $ do
+      let
+        cls =
+          [ Class
+            "x"
+            [ Method
+              "y"
+              [ Path "x"
+              , Dyn (NonEmpty (NonEmpty Number))
+              , Path "y"
+              ]
+            ]
+          ]
+      normalizeText (classesToFlow cls)
+        `shouldBe`
+          normalizeText [st|
+            class x {
+              y(a: Array<Array<number>>): string { return this.root + '/x/' + a.map(function(a1) { return a1.map(function(a2) { return a2.toString() }).join(',') }).join(',') + '/y'; }
+              root: string;
+              constructor(root: string) {
+                this.root = root;
+              }
+            }
+          |]
+
+  describe "genFlowSource" $
+    it "should work end-to-end" $ do
+      let source = genFlowSource [] [] "'test'" resources
+      normalizeText source
+        `shouldBe`
+          normalizeText [st|
+            /* @flow */
+            class PATHS_TYPE_paths {
+              api : PATHS_TYPE_paths_api;
+              static_pages : PATHS_TYPE_paths_static_pages;
+              root: string;
+              constructor(root: string) {
+                this.root = root;
+                this.api = new PATHS_TYPE_paths_api(root);
+                this.static_pages = new PATHS_TYPE_paths_static_pages(root);
+              }
+            }
+            class PATHS_TYPE_paths_static_pages {
+              root: string;
+              constructor(root: string) {
+                this.root = root;
+              }
+            }
+            class PATHS_TYPE_paths_api {
+              users(a: number): string { return this.root + '/api/users/' + a.toString() + ''; }
+              users_bar(a: Array<number>): string { return this.root + '/api/users/' + a.map(function(a1) { return a1.toString() }).join(',') + '/bar'; }
+              users_baz(a: string): string { return this.root + '/api/users/' + a + '/baz'; }
+              users_foo(a: number): string { return this.root + '/api/users/' + a.toString() + '/foo'; }
+              root: string;
+              constructor(root: string) {
+                this.root = root;
+              }
+            }
+            var PATHS: PATHS_TYPE_paths = new PATHS_TYPE_paths('test');
+          |]

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}

--- a/test/TestImport.hs
+++ b/test/TestImport.hs
@@ -1,0 +1,20 @@
+module TestImport
+  ( module X
+  , normalizeText
+  , parseRoutes
+  , ResourceTree(..)
+  , st
+  ) where
+
+import Yesod.Routes.Flow.Generator as X
+
+import ClassyPrelude as X
+import qualified Data.Text as T
+import Text.Shakespeare.Text (st)
+import Test.Hspec as X
+import Yesod.Core.Dispatch (parseRoutes)
+import Yesod.Routes.TH.Types (ResourceTree(..))
+
+-- Avoid having to exactly compare leading whitespace or empty lines
+normalizeText :: Text -> Text
+normalizeText = T.unlines . filter (/="") . (map T.strip) . T.lines

--- a/yesod-routes-flow.cabal
+++ b/yesod-routes-flow.cabal
@@ -42,4 +42,39 @@ library
                         text,
                         yesod-core >= 1.4 && < 2.0
   -- hs-source-dirs:
-  default-language:    Haskell2010
+  default-language:     Haskell2010
+
+test-suite test
+  type:                 exitcode-stdio-1.0
+  main-is:              Spec.hs
+  hs-source-dirs:       test
+  other-modules:
+                        TestImport
+                        GeneratorSpec
+  default-extensions:
+                        ConstraintKinds,
+                        DeriveDataTypeable,
+                        ExtendedDefaultRules,
+                        FlexibleContexts,
+                        FlexibleInstances,
+                        LambdaCase,
+                        NoImplicitPrelude,
+                        OverloadedStrings,
+                        QuasiQuotes
+                        RecordWildCards,
+                        ScopedTypeVariables,
+                        StandaloneDeriving,
+                        TemplateHaskell,
+                        TupleSections,
+                        TypeSynonymInstances
+  build-depends:
+                        base < 5,
+                        yesod-routes-flow,
+                        classy-prelude >= 0.7,
+                        hspec,
+                        hspec-expectations,
+                        semigroups,
+                        shakespeare,
+                        text,
+                        yesod-core >= 1.4 && < 2.0
+  default-language:     Haskell2010


### PR DESCRIPTION
We have a number of places where we pass a list of Ids like so:

```plaintext
/2/assignments/4,5,6/assignment-sessions
```

This is described by the following Yesod config:

```plaintext
...
  /assignments AssignmentsP:
    /#NonEmptyAssignmentId/assignment-sessions  AssignmentsAssignmentSessionsR GET
```

Where `NonEmptyAssignmentId` is a type synonym for `NonEmpty AssignmentId`. When we generate JavaScript for a route like this, we now correctly type it as `Array<number>` and comma-join the input before adding it to the url string.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/frontrowed/yesod-routes-flow/1)
<!-- Reviewable:end -->
