### PR TITLE
Add an override mapping to specify custom types

### DIFF
--- a/Yesod/Routes/Flow/Generator.hs
+++ b/Yesod/Routes/Flow/Generator.hs
@@ -1,4 +1,6 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# LANGUAGE LambdaCase      #-}
+{-# LANGUAGE RecordWildCards #-}
 module Yesod.Routes.Flow.Generator
   ( genFlowRoutes
   , genFlowRoutesPrefix
@@ -11,36 +13,39 @@ module Yesod.Routes.Flow.Generator
   , PieceType(..)
   ) where
 
-import ClassyPrelude hiding (FilePath)
-import Data.Text (dropWhileEnd)
-import Filesystem (createTree, writeTextFile)
-import Filesystem.Path (FilePath, directory)
-import Yesod.Routes.TH.Types
-import qualified Data.Char as C
-import qualified Data.List as L
-import qualified Data.Map  as M
-import qualified Data.Text as T
+import           ClassyPrelude         hiding (FilePath)
+import qualified Data.Char             as C
+import qualified Data.List             as L
+import qualified Data.Map              as M
+import           Data.Text             (dropWhileEnd)
+import qualified Data.Text             as T
+import           Filesystem            (createTree, writeTextFile)
+import           Filesystem.Path       (FilePath, directory)
+import           Yesod.Routes.TH.Types
+
+-- An override map from Haskell type name to Flow type name
+type Overrides = M.Map String PieceType
 
 genFlowRoutes :: [ResourceTree String] -> FilePath -> IO ()
-genFlowRoutes ra fp = genFlowRoutesPrefix [] [] ra fp "''"
+genFlowRoutes ra fp = genFlowRoutesPrefix M.empty [] [] ra fp "''"
 
-genFlowRoutesPrefix :: [String] -> [String] -> [ResourceTree String] -> FilePath -> Text -> IO ()
-genFlowRoutesPrefix routePrefixes elidedPrefixes fullTree fp prefix = do
+genFlowRoutesPrefix :: Overrides -> [String] -> [String] -> [ResourceTree String] -> FilePath -> Text -> IO ()
+genFlowRoutesPrefix overrides routePrefixes elidedPrefixes fullTree fp prefix = do
     createTree $ directory fp
-    writeTextFile fp $ genFlowSource routePrefixes elidedPrefixes prefix fullTree
+    writeTextFile fp $ genFlowSource overrides routePrefixes elidedPrefixes prefix fullTree
 
-genFlowSource :: [String] -> [String] -> Text -> [ResourceTree String] -> Text
-genFlowSource routePrefixes elidedPrefixes prefix fullTree =
+genFlowSource :: Overrides -> [String] -> [String] -> Text -> [ResourceTree String] -> Text
+genFlowSource overrides routePrefixes elidedPrefixes prefix fullTree =
   mconcat
     [ "/* @flow */\n\n"
-    , classesToFlow $ genFlowClasses routePrefixes elidedPrefixes fullTree
+    , classesToFlow $ genFlowClasses overrides routePrefixes elidedPrefixes fullTree
     , "\n\nvar PATHS: PATHS_TYPE_paths = new PATHS_TYPE_paths(" <> prefix <> ");\n"
     ]
 
-genFlowClasses :: [String] -> [String] -> [ResourceTree String] -> [Class]
-genFlowClasses routePrefixes elidedPrefixes fullTree =
+genFlowClasses :: Overrides -> [String] -> [String] -> [ResourceTree String] -> [Class]
+genFlowClasses overrides routePrefixes elidedPrefixes fullTree =
   map disambiguateFields $
-  resourceTreeToClasses elidedPrefixes $
+  resourceTreeToClasses overrides elidedPrefixes $
   ResourceParent "paths" False [] hackedTree
  where
   -- Route hackery.
@@ -55,7 +60,7 @@ genFlowClasses routePrefixes elidedPrefixes fullTree =
 
 parentName :: ResourceTree String -> String -> Bool
 parentName (ResourceParent n _ _ _) name = n == name
-parentName _ _  = False
+parentName _ _                           = False
 
 ----------------------------------------------------------------------
 
@@ -74,17 +79,19 @@ isVariable :: RenderedPiece -> Bool
 isVariable (Path _) = False
 isVariable (Dyn _)  = True
 
-renderRoutePieces :: [Piece String] -> [RenderedPiece]
-renderRoutePieces = map renderRoutePiece
+renderRoutePieces :: Overrides -> [Piece String] -> [RenderedPiece]
+renderRoutePieces overrides = map renderRoutePiece
   where
     renderRoutePiece (Static st)   = Path $ T.dropAround (== '/') $ pack st
     renderRoutePiece (Dynamic typ) = Dyn $ parseType typ
 
     parseType type_ =
-      maybe
-      (parseSimpleType type_)
-      (NonEmptyT . parseType)
-      (L.stripPrefix "NonEmpty" type_) -- NonEmptyUserId ~ NonEmpty UserId
+      fromMaybe
+        (maybe
+          (parseSimpleType type_)
+          (NonEmptyT . parseType)
+          (L.stripPrefix "NonEmpty" type_)) -- NonEmptyUserId ~ NonEmpty UserId
+        $ M.lookup type_ overrides
 
     parseSimpleType "Int" = NumberT
     parseSimpleType type_
@@ -110,8 +117,8 @@ data ClassMember =
       }
     -- | A callable method.
   | Method
-      { cmField     :: Text            -- ^ Field name used to refer to the method.
-      , cmPieces    :: [RenderedPiece] -- ^ Pieces to render the route.
+      { cmField  :: Text            -- ^ Field name used to refer to the method.
+      , cmPieces :: [RenderedPiece] -- ^ Pieces to render the route.
       }
     deriving (Eq, Show)
 
@@ -125,8 +132,8 @@ variableNames = T.cons <$> ['a'..'z'] <*> ("" : variableNames)
 ----------------------------------------------------------------------
 
 -- | Create a list of 'Class'es from a 'ResourceTree'.
-resourceTreeToClasses :: [String] -> ResourceTree String -> [Class]
-resourceTreeToClasses elidedPrefixes = finish . go Nothing []
+resourceTreeToClasses :: Overrides -> [String] -> ResourceTree String -> [Class]
+resourceTreeToClasses overrides elidedPrefixes = finish . go Nothing []
   where
     finish (Right (_, classes)) = classes
     finish (Left _)             = []
@@ -140,13 +147,13 @@ resourceTreeToClasses elidedPrefixes = finish . go Nothing []
             fullName = intercalate "_" [pack st :: Text | Static st <- resourcePieces res]
         return Method
           { cmField       = if null fullName then "_" else resName
-          , cmPieces      = routePrefix <> renderRoutePieces (resourcePieces res) }
+          , cmPieces      = routePrefix <> renderRoutePieces overrides (resourcePieces res) }
     go parent routePrefix (ResourceParent name _ pieces children) =
       let elideThisPrefix = name `elem` elidedPrefixes
           pref            = cleanName $ pack name
           jsName          = maybe "" (<> "_") parent <> pref
           newParent       = if elideThisPrefix then parent else Just jsName
-          newRoutePrefix  = routePrefix <> renderRoutePieces pieces
+          newRoutePrefix  = routePrefix <> renderRoutePieces overrides pieces
           membersMethods  = catMaybes childrenMethods
           (childrenMethods, childrenClasses) = partitionEithers $ map (go newParent newRoutePrefix) children
           (membersClasses, moreClasses)      = concat *** concat $ unzip childrenClasses
@@ -211,8 +218,8 @@ classMemberToFlowDef Method {..}     = "  " <> cmField <> "(" <> args <> "): str
         getType (Path _) = Nothing
         getType (Dyn t)  = Just t
 
-        argType NumberT = "number"
-        argType StringT = "string"
+        argType NumberT       = "number"
+        argType StringT       = "string"
         argType (NonEmptyT t) = "Array<" <> argType t <> ">"
 
     body = "return this.root + '" <> routeStr variableNames cmPieces <> "'"

--- a/Yesod/Routes/Flow/Generator.hs
+++ b/Yesod/Routes/Flow/Generator.hs
@@ -1,5 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-{-# LANGUAGE LambdaCase      #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RecordWildCards #-}
 module Yesod.Routes.Flow.Generator
   ( genFlowRoutes
@@ -13,15 +13,15 @@ module Yesod.Routes.Flow.Generator
   , PieceType(..)
   ) where
 
-import           ClassyPrelude         hiding (FilePath)
-import qualified Data.Char             as C
-import qualified Data.List             as L
-import qualified Data.Map              as M
-import           Data.Text             (dropWhileEnd)
-import qualified Data.Text             as T
-import           Filesystem            (createTree, writeTextFile)
-import           Filesystem.Path       (FilePath, directory)
-import           Yesod.Routes.TH.Types
+import ClassyPrelude hiding (FilePath)
+import qualified Data.Char as C
+import qualified Data.List as L
+import qualified Data.Map as M
+import Data.Text (dropWhileEnd)
+import qualified Data.Text as T
+import Filesystem (createTree, writeTextFile)
+import Filesystem.Path (FilePath, directory)
+import Yesod.Routes.TH.Types
 
 -- An override map from Haskell type name to Flow type name
 type Overrides = M.Map String PieceType

--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ machine:
     version: 7.10.2
   environment:
     PATH: "$HOME/.local/bin:$PATH"
-    STACK_VERSION: 1.5.1
+    STACK_VERSION: 1.6.1
 
 general:
   artifacts:

--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ machine:
     version: 7.10.2
   environment:
     PATH: "$HOME/.local/bin:$PATH"
-    STACK_VERSION: 1.1.2
+    STACK_VERSION: 1.5.1
 
 general:
   artifacts:
@@ -17,8 +17,6 @@ dependencies:
     - "~/.stack"
     - "~/yesod-routes-flow/.stack-work"
   override:
-    - sudo update-alternatives --set gcc /usr/bin/gcc-4.6 # Remove these once Circle CI's GCC 4.9
-    - sudo update-alternatives --set g++ /usr/bin/g++-4.6 # start working with --coverage.
     - stack setup
     - stack build --jobs=1 --test --only-dependencies --no-run-tests:
         timeout: 3600

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-3.2
+resolver: lts-10.2

--- a/yesod-routes-flow.cabal
+++ b/yesod-routes-flow.cabal
@@ -76,5 +76,6 @@ test-suite test
                         semigroups,
                         shakespeare,
                         text,
+                        containers,
                         yesod-core >= 1.4 && < 2.0
   default-language:     Haskell2010

--- a/yesod-routes-flow.cabal
+++ b/yesod-routes-flow.cabal
@@ -1,5 +1,5 @@
 name:                yesod-routes-flow
-version:             2.0
+version:             3.0
 synopsis:            Generate Flow routes for Yesod
 description:         Parse the Yesod routes data structure and generate routes that can be used with Flow.
 homepage:            https://github.com/frontrowed/yesod-routes-flow


### PR DESCRIPTION
Adds a mapping from `String -> PieceType` to allow overriding the default type mapping.

For instance, it's entirely possible that my `User` entity doesn't have a numeric id:

```hs
User sql=users
  Id UUID -- Uh oh!
```

`UUID` should serialize to/from `Text`, but currently `yesod-routes-flow` will generate a type signature that expects a `number` for `User` routes. This is because of a naive matching algorithm that works most of the time.

This PR allows users to specify `Overrides` that will take precedence over this naive matching. In the case above, our `Overrides` would be:

```hs
import qualified Data.Map as M
Yesod.Routes.Flow.Generator (PieceType(..))

overrides = M.singleton "UserId" StringT
```