### PR TITLE
Only derive `Show` for `FlatResource` and `ResourceTree` if yesod-cor…

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,4 @@
+## 3.0.0.1
+
+* Starting in `yesod-core-1.6.2`, `yesod-core` started deriving `Show` for `ResourceTree` and `FlatResource`. To prevent duplicate instance errors, this package now only derives `Show` for `yesod-core < 1.6.2`.
+* An implication of this is that building anything less than `yesod-routes-flow-3.0.0.1` with `yesod-core-1.6.2` will cause duplicate instance compiler errors.

--- a/Yesod/Routes/Flow/Generator.hs
+++ b/Yesod/Routes/Flow/Generator.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RecordWildCards #-}
 module Yesod.Routes.Flow.Generator
@@ -264,5 +265,7 @@ classToFlow Class {..} =
 classesToFlow :: [Class] -> Text
 classesToFlow = intercalate "\n" . map classToFlow
 
+#if !MIN_VERSION_yesod_core(1, 6, 2)
 deriving instance (Show a) => Show (ResourceTree a)
 deriving instance (Show a) => Show (FlatResource a)
+#endif

--- a/yesod-routes-flow.cabal
+++ b/yesod-routes-flow.cabal
@@ -1,5 +1,5 @@
 name:                yesod-routes-flow
-version:             3.0
+version:             3.0.0.1
 synopsis:            Generate Flow routes for Yesod
 description:         Parse the Yesod routes data structure and generate routes that can be used with Flow.
 homepage:            https://github.com/frontrowed/yesod-routes-flow
@@ -10,7 +10,7 @@ maintainer:          Greg Weber <greg@frontrowed.com>
 -- copyright:
 category:            Web
 build-type:          Simple
-extra-source-files:  README.md
+extra-source-files:  README.md Changelog.md
 cabal-version:       >=1.10
 
 library


### PR DESCRIPTION
…e < 1.6.2

Hi, I recently added this PR to `yesod-core` which derives a `Show` instance for `ResourceTree` and `FlatResource`. It'd be much better for it to be derived there than here, so users get it by default and multiple packages can use `Show` without defining their own instance.

If that PR is merged, can you merge this PR, so that users can update their version of `yesod-routes-flow` to avoid duplicate instance errors?

I added a Changelog describing this change—I can't delete that if you don't want one.

I tested with the following additions to the `stack.yaml` file:

```
extra-deps:
  - /Users/maximiliantagher/Documents/Clones/Haskell/yesodweb/yesod/yesod-core # 1.6.2, currently unreleased
  - conduit-1.3.0
  - resourcet-1.2.0
  - conduit-extra-1.3.0
  - monad-logger-0.3.28.1

allow-newer: true
```